### PR TITLE
Allow turtle_do to work within functions

### DIFF
--- a/R/do.R
+++ b/R/do.R
@@ -52,8 +52,8 @@ turtle_do <- function(expr){
    curVisible <- get("visible", envir=.turtle_data)
    if (curVisible)
       turtle_hide()
-   
-   eval(substitute(expr), enclos = parent.frame())
+   print(ls(parent.frame()))
+   eval(substitute(expr), envir = parent.frame())
    
    if (curVisible)
       turtle_show()

--- a/R/do.R
+++ b/R/do.R
@@ -52,7 +52,6 @@ turtle_do <- function(expr){
    curVisible <- get("visible", envir=.turtle_data)
    if (curVisible)
       turtle_hide()
-   print(ls(parent.frame()))
    eval(substitute(expr), envir = parent.frame())
    
    if (curVisible)


### PR DESCRIPTION
Currently `turtle_do()` does not scope properly within functions.  For example, the following:

```
turtle_square <- function(side) {
  turtle_do({
    for (i in 1:4) {
      turtle_forward(side)
      turtle_right(90)
      }
  })
}
turtle_init()
turtle_square(10)
```
throws an error:  "object 'side' not found".

The proposed change fixes this.